### PR TITLE
Update solana version and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Among other things, the above command will modify your new instance by
 - increasing the file descriptor limit for processes managed by supervisor to 600000
 - creating a `tmpfs` device for the accounts store mounted at `/mnt/accounts`
 
-After running the `setup.yaml` script, a reboot is necessary to pick up various system configs. Post-reboot, supervisor 
-should start up the validator using the `sol/api.sh` script. The validator will be listening on port 8899 for rest 
-requests, so issuing a curl to the `/health` path will return the health status of the validator.
+After running the `setup.yaml` script, a reboot is necessary to pick up various system configs. If it is the first time
+that the validator starts, it is possible that it thinks that a local ledger is present when there is not: commenting out the
+lines 64-66 of `deploy/api.sh` will prevent this. Post-reboot, supervisor should start up the validator using the
+`sol/api.sh` script. The validator will be listening on port 8899 for rest requests, so issuing a curl to the `/health`
+path will return the health status of the validator.
 ```
 $ curl http://localhost:8899
 ``` 

--- a/deploy/hosts.yaml
+++ b/deploy/hosts.yaml
@@ -1,7 +1,7 @@
 all:
   vars:
     validator_user: sol
-    solana_version: v1.4.9
+    solana_version: v1.4.24
     run_validator: true
     nginx_sites:
       - validator.conf

--- a/deploy/setup.yaml
+++ b/deploy/setup.yaml
@@ -155,7 +155,7 @@
   tasks:
     - name: update git
       git:
-        repo: git@github.com:project-serum/validators.git
+        repo: https://github.com/project-serum/validators.git
         dest: "~/{{ validator_user }}"
         version: "{{ commit | default('HEAD')}}"
 

--- a/sol/api.sh
+++ b/sol/api.sh
@@ -61,8 +61,8 @@ args=(
 
 # Note: can get into a bad state that requires actually fetching a new snapshot. One such error that indicates this:
 # "...processing for bank 0 must succeed: FailedToLoadEntries(InvalidShredData(Custom(\"could not reconstruct entries\")))"
-#if [[ -d /data/sol/ledger ]]; then
-#  args+=(--no-snapshot-fetch)
-#fi
+if [[ -d /data/sol/ledger ]]; then
+  args+=(--no-snapshot-fetch)
+fi
 
 exec solana-validator "${args[@]}"

--- a/sol/api.sh
+++ b/sol/api.sh
@@ -61,8 +61,8 @@ args=(
 
 # Note: can get into a bad state that requires actually fetching a new snapshot. One such error that indicates this:
 # "...processing for bank 0 must succeed: FailedToLoadEntries(InvalidShredData(Custom(\"could not reconstruct entries\")))"
-if [[ -d /data/sol/ledger ]]; then
-  args+=(--no-snapshot-fetch)
-fi
+#if [[ -d /data/sol/ledger ]]; then
+#  args+=(--no-snapshot-fetch)
+#fi
 
 exec solana-validator "${args[@]}"


### PR DESCRIPTION
These are some minor fixes for bugs that we encountered when deploying a solana validator:

- Update the solana version used from 1.4.9 to 1.4.24. This seemed to remove the following crash of solana-validator during start-up: `from snapshot failed: Serialize(Io(Custom { kind: Other, error: Error { kind: Other, message: "other os error" } }))', ledger/src/bank_forks_utils.rs:71:18`
- Replace the ssh address of this repo in `setup.yaml` with the https address. Ansible couldn't clone the repo, giving a git permission error
- Comment out the `--no-snapshot-fetch` flag in `api.sh` as the condition seemed to be always satisfied and hence crashed solana-validator as it couldn't find a local ledger.

